### PR TITLE
Update RLBot NuGet version to 1.2.3

### DIFF
--- a/RLBotCSharpExample/RLBotCSharpExample/RLBotCSharpExample.csproj
+++ b/RLBotCSharpExample/RLBotCSharpExample/RLBotCSharpExample.csproj
@@ -54,10 +54,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FlatBuffers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RLBot.Framework.1.1.0\lib\net461\FlatBuffers.dll</HintPath>
+      <HintPath>..\packages\RLBot.Framework.1.2.3\lib\net461\FlatBuffers.dll</HintPath>
     </Reference>
-    <Reference Include="RLBotDotNet, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RLBot.Framework.1.1.0\lib\net461\RLBotDotNet.dll</HintPath>
+    <Reference Include="RLBotDotNet, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RLBot.Framework.1.2.3\lib\net461\RLBotDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/RLBotCSharpExample/RLBotCSharpExample/packages.config
+++ b/RLBotCSharpExample/RLBotCSharpExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RLBot.Framework" version="1.1.0" targetFramework="net461" />
+  <package id="RLBot.Framework" version="1.2.3" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This will allow people to use all the new rlbot features by default.