### PR TITLE
Update RLBot.Framework to 2.0.0

### DIFF
--- a/CSharpBot/Bot/App.config
+++ b/CSharpBot/Bot/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/CSharpBot/Bot/Bot.cs
+++ b/CSharpBot/Bot/Bot.cs
@@ -1,5 +1,5 @@
-﻿using System.Numerics;
-using System.Windows.Media;
+﻿using System.Drawing;
+using System.Numerics;
 using Bot.Utilities.Processed.BallPrediction;
 using Bot.Utilities.Processed.FieldInfo;
 using Bot.Utilities.Processed.Packet;
@@ -21,8 +21,8 @@ namespace Bot
 
             // Get the data required to drive to the ball.
             Vector3 ballLocation = packet.Ball.Physics.Location;
-            Vector3 carLocation = packet.Players[index].Physics.Location;
-            Orientation carRotation = packet.Players[index].Physics.Rotation;
+            Vector3 carLocation = packet.Players[Index].Physics.Location;
+            Orientation carRotation = packet.Players[Index].Physics.Rotation;
 
             // Find where the ball is relative to us.
             Vector3 ballRelativeLocation = Orientation.RelativeLocation(carLocation, ballLocation, carRotation);
@@ -36,9 +36,9 @@ namespace Bot
                 steer = -1;
             
             // Examples of rendering in the game
-            Renderer.DrawString3D("Ball", Colors.Black, ballLocation, 3, 3);
-            Renderer.DrawString3D(steer > 0 ? "Right" : "Left", Colors.Aqua, carLocation, 3, 3);
-            Renderer.DrawLine3D(Colors.Red, carLocation, ballLocation);
+            Renderer.DrawString3D("Ball", Color.Black, ballLocation, 3, 3);
+            Renderer.DrawString3D(steer > 0 ? "Right" : "Left", Color.Aqua, carLocation, 3, 3);
+            Renderer.DrawLine3D(Color.Red, carLocation, ballLocation);
             
             // This controller will contain all the inputs that we want the bot to perform.
             return new Controller

--- a/CSharpBot/Bot/Bot.csproj
+++ b/CSharpBot/Bot/Bot.csproj
@@ -54,15 +54,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FlatBuffers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RLBot.Framework.1.12.2\lib\net461\FlatBuffers.dll</HintPath>
+      <HintPath>..\packages\RLBot.Framework.2.0.0\lib\netstandard2.0\FlatBuffers.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="RLBotDotNet, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RLBot.Framework.1.12.2\lib\net461\RLBotDotNet.dll</HintPath>
+    <Reference Include="RLBotDotNet, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RLBot.Framework.2.0.0\lib\netstandard2.0\RLBotDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/CSharpBot/Bot/packages.config
+++ b/CSharpBot/Bot/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RLBot.Framework" version="1.12.2" targetFramework="net461" />
+  <package id="RLBot.Framework" version="2.0.0" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The RLBotCSharpExample solution will not build as-is. The RLBot.Framework version 1.12.2 referenced currently does not contain the RLBotDotNet dependencies referenced in the Bot.cs file.

This PR has changes that update the RLBot.Framework to the most stable version (2.0.0) following these patch notes to address any breaking changes and relevant refactoring:
https://www.nuget.org/packages/RLBot.Framework/2.0.0
and
https://github.com/RLBot/RLBotCSharpExample/wiki/Upgrading-to-RLBotDotNet-2.x

Benefits:
Figured this PR would help anyone wanting to clone the Repo and immediately be able to interact with the example Bot.cs file without worrying about dependencies and backwards compatibility between major versions.

Drawbacks:
None that I can think of. Unless this is the desired experience.

Testing:
Solution as-is won't compile due to the example Bot.cs file referencing an unavailable namespace due to the RLBot.Framework version 1.12.2 referenced.
After these changes, the solution compiles and works as expected with RLBot.
